### PR TITLE
Support Jenkins-style H (hash) schedules

### DIFF
--- a/cron_test.go
+++ b/cron_test.go
@@ -106,7 +106,7 @@ func TestParseFail(t *testing.T) {
 		{"H * * * *", ErrParseHashedSchedule},
 		{"* H/4 * * *", ErrParseHashedSchedule},
 		{"* 1,H/4 * * *", ErrParseHashedSchedule},
-		{"H(1-5), * * * *", nil},
+		{"H(1-5) * * * *", nil},
 	} {
 		t.Run(tt.expr, func(t *testing.T) {
 			_, err := Parse(tt.expr)


### PR DESCRIPTION
closes #1

Adds a new `ParseWithHash` function to support "hashed" schedules like `H * * * *`. The `H` symbol is used to randomize scheduled start times to more evenly distribute resource usage, while still maintaining a consistent schedule period (e.g. once per hour).

This implementation adds a `hashedFields` which takes a seed value to generate a deterministic set of random field values that will be used for substituting any `H` values in the schedule expression. This does guarantee some stability in the schedule randomness even when the expression is modified.

For example, a schedule like `0 H * * *` might be realized to `0 11 * * *`, or every day at the 11:00. Changing the schedule to `H H * * *` will maintain the random hour value so you'd end up with a schedule like `41 11 * * *`.

Note that there are no guarantees for schedule stability when it comes to interval schedules like `H H/6 * * *`. That is, modifying this schedule to something like `H/15 H/6 * * *` would result in a different randomized hour schedule. Though that would be a very strange schedule to use anyway.

This is because the 5 individual random field values are pregenerated regardless of whether they are used, ensuring that they're generated in the same order every time. This does not do the same for interval schedules, though there are a finite number of valid intervals for each fields so it would be possible to do the same. I'm not sure that this particular behavior is a must-have though.