### PR TITLE
Assorted cleanup

### DIFF
--- a/cron.go
+++ b/cron.go
@@ -87,8 +87,8 @@ func ParseWithHash(expr string, seed uint64) (*Schedule, error) {
 	return schedule, nil
 }
 
+// parseError tries to construct a friendlier error message.
 func parseError(expr string, err error) error {
-	// Just for a friendlier error message
 	if strings.HasPrefix(expr, "@") {
 		return fmt.Errorf("unrecognized cron schedule name: %q", expr)
 	}
@@ -259,8 +259,6 @@ var dowNames = []string{
 	"saturday",
 }
 
-// parseFields returns a ErrParseHashedSchedule if part uses the H symbol and hf
-// is nil.
 func parseFields(expr string, hf *hashedFields) (*Schedule, error) {
 	var schedule Schedule
 	fields := strings.Fields(expr)
@@ -326,8 +324,8 @@ func parseSinglePart(part string, fieldIndex int, hf *hashedFields) (*Schedule, 
 				rangeStart = hf.fields[fieldIndex]
 				rangeEnd = rangeStart
 			} else {
-				// For interval schedules like H/n, generate a random start time offset
-				// between [0, n).
+				// For interval schedules like H/n,
+				// generate a random start time offset in [0, n).
 				rangeStart = hf.rng.Intn(inc)
 				rangeEnd = fieldSizes[fieldIndex] - 1
 			}
@@ -439,7 +437,7 @@ func newHashedFields(seed uint64) *hashedFields {
 	for fieldIndex := 0; fieldIndex < 5; fieldIndex++ {
 		n := fieldSizes[fieldIndex]
 		if fieldIndex == 2 {
-			// Only generate random days of the month in a range of [0, 28]
+			// Only generate random days of the month in [0, 28].
 			n = 29
 		}
 		val := rng.Intn(n)

--- a/cron_test.go
+++ b/cron_test.go
@@ -13,7 +13,7 @@ import (
 // Must be in sorted order. nil == '*'
 type testSchedule [5][]int
 
-func assertSchedule(t *testing.T, ts testSchedule, s *Schedule) {
+func assertSchedule(t *testing.T, ts testSchedule, s Schedule) {
 	t.Helper()
 	for i, size := range fieldSizes {
 		set := ts[i]

--- a/cron_test.go
+++ b/cron_test.go
@@ -19,7 +19,11 @@ func toTestSchedule(s Schedule) testSchedule {
 		allSet := true
 		for j := 0; j < size; j++ {
 			if s.isSet(fieldOffsets[i] + j) {
-				part = append(part, j)
+				v := j
+				if i == 2 || i == 3 {
+					v++
+				}
+				part = append(part, v)
 			} else {
 				allSet = false
 			}
@@ -38,19 +42,19 @@ func TestParse(t *testing.T) {
 		want testSchedule
 	}{
 		{"* * * * *", testSchedule{nil, nil, nil, nil, nil}},
-		{"0 0 1 1 0", testSchedule{{0}, {0}, {0}, {0}, {0}}},
+		{"0 0 1 1 0", testSchedule{{0}, {0}, {1}, {1}, {0}}},
 		{"2,3 * * * *", testSchedule{{2, 3}, nil, nil, nil, nil}},
 		{"2-5 * * * *", testSchedule{{2, 3, 4, 5}, nil, nil, nil, nil}},
 		{"1,3-5 * * * *", testSchedule{{1, 3, 4, 5}, nil, nil, nil, nil}},
 		{"1,3-5,10-45/10,58 * * * *", testSchedule{{1, 3, 4, 5, 10, 20, 30, 40, 58}, nil, nil, nil, nil}},
 		{"* 21-3 * * *", testSchedule{nil, {0, 1, 2, 3, 21, 22, 23}, nil, nil, nil}},
-		{"* * * JAN *", testSchedule{nil, nil, nil, {0}, nil}},
-		{"* * * Janua *", testSchedule{nil, nil, nil, {0}, nil}},
-		{"* * * APR-JUL *", testSchedule{nil, nil, nil, {3, 4, 5, 6}, nil}},
+		{"* * * JAN *", testSchedule{nil, nil, nil, {1}, nil}},
+		{"* * * Janua *", testSchedule{nil, nil, nil, {1}, nil}},
+		{"* * * APR-JUL *", testSchedule{nil, nil, nil, {4, 5, 6, 7}, nil}},
 		{"* * * * MON,WED", testSchedule{nil, nil, nil, nil, {1, 3}}},
 		{"* */6 * * *", testSchedule{nil, {0, 6, 12, 18}, nil, nil, nil}},
 		{"* 6-10/2 * * *", testSchedule{nil, {6, 8, 10}, nil, nil, nil}},
-		{"@monthly", testSchedule{{0}, {0}, {0}, nil, nil}},
+		{"@monthly", testSchedule{{0}, {0}, {1}, nil, nil}},
 		{"@weekly", testSchedule{{0}, {0}, nil, nil, {0}}},
 		{"@daily", testSchedule{{0}, {0}, nil, nil, nil}},
 		{"@hourly", testSchedule{{0}, nil, nil, nil, nil}},
@@ -129,22 +133,22 @@ func TestParseH(t *testing.T) {
 		{"H H * * *", []int{14, 15}, testSchedule{{14}, {15}, nil, nil, nil}},
 		{"@weekly", []int{16, 17, 18}, testSchedule{{16}, {17}, nil, nil, {4}}},
 		{"H H * * H", []int{19}, testSchedule{{19}, {19}, nil, nil, {5}}},
-		{"@monthly", []int{27, 21}, testSchedule{{27}, {21}, {27}, nil, nil}},
-		{"H H H * *", []int{28, 21}, testSchedule{{28}, {21}, {0}, nil, nil}},
+		{"@monthly", []int{27, 21}, testSchedule{{27}, {21}, {28}, nil, nil}},
+		{"H H H * *", []int{28, 21}, testSchedule{{28}, {21}, {1}, nil, nil}},
 		{"H 0 * * *", []int{22}, testSchedule{{22}, {0}, nil, nil, nil}},
 		{"@weekly", []int{23, 24}, testSchedule{{23}, {0}, nil, nil, {2}}},
-		{"H H H H H", []int{25, 26}, testSchedule{{25}, {2}, {25}, {2}, {4}}},
-		{"H H H H H", []int{0}, testSchedule{{0}, {0}, {0}, {0}, {0}}},
-		{"H H H H H", []int{59, 23, 27, 11, 6}, testSchedule{{59}, {23}, {27}, {11}, {6}}},
-		{"H H H H H", []int{60, 24, 28, 12, 7}, testSchedule{{0}, {0}, {0}, {0}, {0}}},
-		{"* * H/30 * *", []int{30}, testSchedule{nil, nil, {2}, nil, nil}},
+		{"H H H H H", []int{25, 26}, testSchedule{{25}, {2}, {26}, {3}, {4}}},
+		{"H H H H H", []int{0}, testSchedule{{0}, {0}, {1}, {1}, {0}}},
+		{"H H H H H", []int{59, 23, 27, 11, 6}, testSchedule{{59}, {23}, {28}, {12}, {6}}},
+		{"H H H H H", []int{60, 24, 28, 12, 7}, testSchedule{{0}, {0}, {1}, {1}, {0}}},
+		{"* * H/30 * *", []int{30}, testSchedule{nil, nil, {3}, nil, nil}},
 		{"H H * * H", []int{3, 4, 5}, testSchedule{{3}, {4}, nil, nil, {5}}},
 		{"H/1 * * * *", []int{3}, testSchedule{nil, nil, nil, nil, nil}},
 		{"* H/6 * * *", []int{10}, testSchedule{nil, {4, 10, 16, 22}, nil, nil, nil}},
 		{"H H/6 * * *", []int{11, 12}, testSchedule{{11}, {0, 6, 12, 18}, nil, nil, nil}},
 		{"H/15 H/6 * * *", []int{64, 1}, testSchedule{{4, 19, 34, 49}, {1, 7, 13, 19}, nil, nil, nil}},
-		{"H H/12 * March *", []int{14, 4}, testSchedule{{14}, {4, 16}, nil, {2}, nil}},
-		{"H * * MARCH *", []int{14, 4}, testSchedule{{14}, nil, nil, {2}, nil}},
+		{"H H/12 * March *", []int{14, 4}, testSchedule{{14}, {4, 16}, nil, {3}, nil}},
+		{"H * * MARCH *", []int{14, 4}, testSchedule{{14}, nil, nil, {3}, nil}},
 	} {
 		s, err := parseH(tt.expr, &fixedRNG{vals: tt.randVals})
 		if err != nil {

--- a/cron_test.go
+++ b/cron_test.go
@@ -1,57 +1,48 @@
 package cron
 
 import (
-	"fmt"
-	"math/rand"
-	"sort"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 // One []int each for minutes, hours, ...
 // Must be in sorted order. nil == '*'
 type testSchedule [5][]int
 
-func assertSchedule(t *testing.T, ts testSchedule, s Schedule) {
-	t.Helper()
+func toTestSchedule(s Schedule) testSchedule {
+	var ts testSchedule
 	for i, size := range fieldSizes {
-		set := ts[i]
-		if set == nil {
-			for j := 0; j < size; j++ {
-				set = append(set, j)
-			}
-		}
+		var part []int
+		allSet := true
 		for j := 0; j < size; j++ {
-			setInS := s.isSet(fieldOffsets[i] + j)
-			setInTestCase := true
-			index := sort.SearchInts(set, j)
-			if index == len(set) || set[index] != j {
-				setInTestCase = false
-			}
-			if setInS != setInTestCase {
-				t.Fatalf("got %v; want %v\n", s, ts)
+			if s.isSet(fieldOffsets[i] + j) {
+				part = append(part, j)
+			} else {
+				allSet = false
 			}
 		}
+		if allSet {
+			part = nil
+		}
+		ts[i] = part
 	}
-}
-
-type parseTestCase struct {
-	expr   string
-	parsed testSchedule
+	return ts
 }
 
 func TestParseWithoutHash(t *testing.T) {
-	for _, testCase := range []parseTestCase{
+	for _, tt := range []struct {
+		expr string
+		want testSchedule
+	}{
 		{"* * * * *", testSchedule{nil, nil, nil, nil, nil}},
 		{"0 0 1 1 0", testSchedule{{0}, {0}, {0}, {0}, {0}}},
 		{"2,3 * * * *", testSchedule{{2, 3}, nil, nil, nil, nil}},
 		{"2-5 * * * *", testSchedule{{2, 3, 4, 5}, nil, nil, nil, nil}},
 		{"1,3-5 * * * *", testSchedule{{1, 3, 4, 5}, nil, nil, nil, nil}},
-		{
-			"1,3-5,10-45/10,58 * * * *",
-			testSchedule{{1, 3, 4, 5, 10, 20, 30, 40, 58}, nil, nil, nil, nil},
-		},
+		{"1,3-5,10-45/10,58 * * * *", testSchedule{{1, 3, 4, 5, 10, 20, 30, 40, 58}, nil, nil, nil, nil}},
 		{"* 21-3 * * *", testSchedule{nil, {0, 1, 2, 3, 21, 22, 23}, nil, nil, nil}},
 		{"* * * JAN *", testSchedule{nil, nil, nil, {0}, nil}},
 		{"* * * Janua *", testSchedule{nil, nil, nil, {0}, nil}},
@@ -64,98 +55,105 @@ func TestParseWithoutHash(t *testing.T) {
 		{"@daily", testSchedule{{0}, {0}, nil, nil, nil}},
 		{"@hourly", testSchedule{{0}, nil, nil, nil, nil}},
 	} {
-		t.Run(testCase.expr, func(t *testing.T) {
-			s, err := Parse(testCase.expr)
-			if err != nil {
-				t.Fatal(err)
-			}
-			assertSchedule(t, testCase.parsed, s)
-			// ParseWithHash should return the same schedule as Parse when the
-			// expression does not contain the H symbol.
-			if !strings.HasPrefix(testCase.expr, "@") {
-				s, err = ParseWithHash(testCase.expr, rand.Uint64())
-				if err != nil {
-					t.Fatal(err)
-				}
-				assertSchedule(t, testCase.parsed, s)
-			}
-		})
+		s, err := Parse(tt.expr)
+		if err != nil {
+			t.Errorf("Parse(%q): %s", tt.expr, err)
+			continue
+		}
+		if diff := cmp.Diff(toTestSchedule(s), tt.want); diff != "" {
+			t.Errorf("Parse(%q): (-got, +want):\n%s", tt.expr, diff)
+			continue
+		}
+		if strings.HasPrefix(tt.expr, "@") {
+			continue
+		}
+		// ParseWithHash should return the same schedule as Parse when the
+		// expression does not contain the H symbol.
+		s, err = ParseWithHash(tt.expr, 0)
+		if err != nil {
+			t.Errorf("ParseWithHash(%q): %s", tt.expr, err)
+			continue
+		}
+		if diff := cmp.Diff(toTestSchedule(s), tt.want); diff != "" {
+			t.Errorf("ParseWithHash(%q): (-got, +want):\n%s", tt.expr, diff)
+			continue
+		}
 	}
 }
 
 func TestParseFail(t *testing.T) {
 	for _, tt := range []struct {
 		expr string
-		want error // nil for any error
+		want string // substring
 	}{
-		{"* * * *", nil},
-		{"-1 * * * *", nil},
-		{"60 * * * *", nil},
-		{"* 24 * * *", nil},
-		{"* * 0 * *", nil},
-		{"* * 32 * *", nil},
-		{"* * * 0 *", nil},
-		{"* * * 13 *", nil},
-		{"* * * J *", nil},
-		{"* * * foo *", nil},
-		{"* * * * 7", nil},
-		{"1 - 3 * * * *", nil},
-		{"1-3-7 * * * *", nil},
-		{"1/3/7 * * * *", nil},
-		{"@foobar", nil},
-		{"H * * * *", ErrParseHashedSchedule},
-		{"* H/4 * * *", ErrParseHashedSchedule},
-		{"* 1,H/4 * * *", ErrParseHashedSchedule},
-		{"H(1-5) * * * *", nil},
+		{"* * * *", "wrong number of fields"},
+		{"-1 * * * *", "invalid value"},
+		{"60 * * * *", "invalid value"},
+		{"* 24 * * *", "invalid value"},
+		{"* * 0 * *", "invalid value"},
+		{"* * 32 * *", "invalid value"},
+		{"* * * 0 *", "invalid value"},
+		{"* * * 13 *", "invalid value"},
+		{"* * * J *", "invalid value"},
+		{"* * * foo *", "invalid value"},
+		{"* * * * 7", "invalid value"},
+		{"1 - 3 * * * *", "wrong number of fields"},
+		{"1-3-7 * * * *", "invalid value"},
+		{"1/3/7 * * * *", "invalid increment"},
+		{"@foobar", "unrecognized cron schedule"},
+		{"H * * * *", `the "H" symbol`},
+		{"* H/4 * * *", `the "H" symbol`},
+		{"* 1,H/4 * * *", `the "H" symbol`},
+		{"H(1-5) * * * *", "invalid value"},
 	} {
-		t.Run(tt.expr, func(t *testing.T) {
-			_, err := Parse(tt.expr)
-			if err == nil {
-				t.Fatalf("Parse accepted %q, but it is invalid", tt.expr)
-			}
-			if tt.want != nil && err != tt.want {
-				t.Errorf("Parse returned an unexpected error: %s", err)
-			}
-		})
+		_, err := Parse(tt.expr)
+		if err == nil {
+			t.Errorf("Parse accepted %q, but it is invalid", tt.expr)
+			continue
+		}
+		if !strings.Contains(err.Error(), tt.want) {
+			t.Errorf("Parse(%q): got error %q; want substring %q", tt.expr, err, tt.want)
+		}
 	}
 }
 
-type parseHashedTestCase struct {
-	expr   string
-	seed   uint64
-	parsed testSchedule
-}
-
 func TestParseWithHash(t *testing.T) {
-	for _, testCase := range []parseHashedTestCase{
-		{"@hourly", 1, testSchedule{{41}, nil, nil, nil, nil}},
-		{"H * * * *", 1, testSchedule{{41}, nil, nil, nil, nil}},
-		{"@daily", 1, testSchedule{{41}, {15}, nil, nil, nil}},
-		{"H H * * *", 1, testSchedule{{41}, {15}, nil, nil, nil}},
-		{"@weekly", 1, testSchedule{{41}, {15}, nil, nil, {6}}},
-		{"H H * * H", 1, testSchedule{{41}, {15}, nil, nil, {6}}},
-		{"@monthly", 1, testSchedule{{41}, {15}, {0}, nil, nil}},
-		{"H H H * *", 1, testSchedule{{41}, {15}, {0}, nil, nil}},
-
-		{"H 0 * * *", 1, testSchedule{{41}, {0}, nil, nil, nil}},
-		{"@weekly", 10, testSchedule{{14}, {16}, nil, nil, {5}}},
-		{"H H H H H", 10, testSchedule{{14}, {16}, {11}, {11}, {5}}},
-		{"H H * * H", 100, testSchedule{{43}, {8}, nil, nil, {1}}},
-		{"@monthly", 100, testSchedule{{43}, {8}, {11}, nil, nil}},
-		{"H/1 * * * *", 1, testSchedule{nil, nil, nil, nil, nil}},
-		{"* H/6 * * *", 10, testSchedule{nil, {4, 10, 16, 22}, nil, nil, nil}},
-		{"H H/6 * * *", 10, testSchedule{{14}, {4, 10, 16, 22}, nil, nil, nil}},
-		{"H/15 H/6 * * *", 10, testSchedule{{4, 19, 34, 49}, {1, 7, 13, 19}, nil, nil, nil}},
-		{"H H/12 * MARCH *", 10, testSchedule{{14}, {4, 16}, nil, {2}, nil}},
-		{"H * * MARCH *", 10, testSchedule{{14}, nil, nil, {2}, nil}},
+	for _, tt := range []struct {
+		expr     string
+		randVals []int
+		want     testSchedule
+	}{
+		{"@hourly", []int{10}, testSchedule{{10}, nil, nil, nil, nil}},
+		{"H * * * *", []int{11}, testSchedule{{11}, nil, nil, nil, nil}},
+		{"@daily", []int{12, 13}, testSchedule{{12}, {13}, nil, nil, nil}},
+		{"H H * * *", []int{14, 15}, testSchedule{{14}, {15}, nil, nil, nil}},
+		{"@weekly", []int{16, 17, 18}, testSchedule{{16}, {17}, nil, nil, {4}}},
+		{"H H * * H", []int{19}, testSchedule{{19}, {19}, nil, nil, {5}}},
+		{"@monthly", []int{27, 21}, testSchedule{{27}, {21}, {27}, nil, nil}},
+		{"H H H * *", []int{28, 21}, testSchedule{{28}, {21}, {0}, nil, nil}},
+		{"H 0 * * *", []int{22}, testSchedule{{22}, {0}, nil, nil, nil}},
+		{"@weekly", []int{23, 24}, testSchedule{{23}, {0}, nil, nil, {2}}},
+		{"H H H H H", []int{25, 26}, testSchedule{{25}, {2}, {25}, {2}, {4}}},
+		{"H H H H H", []int{0}, testSchedule{{0}, {0}, {0}, {0}, {0}}},
+		{"H H H H H", []int{59, 23, 27, 11, 6}, testSchedule{{59}, {23}, {27}, {11}, {6}}},
+		{"H H H H H", []int{60, 24, 28, 12, 7}, testSchedule{{0}, {0}, {0}, {0}, {0}}},
+		{"H H * * H", []int{3, 4, 5}, testSchedule{{3}, {4}, nil, nil, {5}}},
+		{"H/1 * * * *", []int{3}, testSchedule{nil, nil, nil, nil, nil}},
+		{"* H/6 * * *", []int{10}, testSchedule{nil, {4, 10, 16, 22}, nil, nil, nil}},
+		{"H H/6 * * *", []int{11, 12}, testSchedule{{11}, {0, 6, 12, 18}, nil, nil, nil}},
+		{"H/15 H/6 * * *", []int{64, 1}, testSchedule{{4, 19, 34, 49}, {1, 7, 13, 19}, nil, nil, nil}},
+		{"H H/12 * March *", []int{14, 4}, testSchedule{{14}, {4, 16}, nil, {2}, nil}},
+		{"H * * MARCH *", []int{14, 4}, testSchedule{{14}, nil, nil, {2}, nil}},
 	} {
-		t.Run(fmt.Sprintf("%s %d", testCase.expr, testCase.seed), func(t *testing.T) {
-			s, err := ParseWithHash(testCase.expr, testCase.seed)
-			if err != nil {
-				t.Fatal(err)
-			}
-			assertSchedule(t, testCase.parsed, s)
-		})
+		s, err := parseWithHash(tt.expr, &fixedRNG{vals: tt.randVals})
+		if err != nil {
+			t.Errorf("parseWithHash(%q, %v): %s", tt.expr, tt.randVals, err)
+			continue
+		}
+		if diff := cmp.Diff(toTestSchedule(s), tt.want); diff != "" {
+			t.Errorf("parseWithHash(%q, %v): (-got, +want):\n%s", tt.expr, tt.randVals, diff)
+			continue
+		}
 	}
 }
 
@@ -172,15 +170,19 @@ func TestValid(t *testing.T) {
 	}
 }
 
-type nextTestCase struct {
-	expr   string
-	t1, t2 string
-}
-
-const testTimeLayout = "2006-01-02 15:04"
-
 func TestNext(t *testing.T) {
-	for _, testCase := range []nextTestCase{
+	const layout = "2006-01-02 15:04"
+	parseTime := func(s string) time.Time {
+		t, err := time.Parse(layout, s)
+		if err != nil {
+			panic(err)
+		}
+		return t
+	}
+	for _, tt := range []struct {
+		expr   string
+		t1, t2 string
+	}{
 		{"* * * * *", "2014-01-01 00:00", "2014-01-01 00:01"},
 		{"10 * * * *", "2014-01-01 00:00", "2014-01-01 00:10"},
 		{"* 3 3 * *", "2014-01-01 00:00", "2014-01-03 03:00"},
@@ -188,22 +190,16 @@ func TestNext(t *testing.T) {
 		// June is the first month with the 9th == monday
 		{"* * 9 * Monday", "2014-01-01 00:00", "2014-06-09 00:00"},
 	} {
-		s, err := Parse(testCase.expr)
+		s, err := Parse(tt.expr)
 		if err != nil {
-			t.Fatal(err)
+			t.Errorf("Parse(%q): %s", tt.expr, err)
+			continue
 		}
-		t1, err := time.Parse(testTimeLayout, testCase.t1)
-		if err != nil {
-			t.Fatal(err)
-		}
-		t2, err := time.Parse(testTimeLayout, testCase.t2)
-		if err != nil {
-			t.Fatal(err)
-		}
+		t1, t2 := parseTime(tt.t1), parseTime(tt.t2)
 		got := s.Next(t1)
 		if got != t2 {
-			t.Errorf("got next(%q, %q) = %q; want %q", testCase.expr, t1.Format(testTimeLayout),
-				got.Format(testTimeLayout), t2.Format(testTimeLayout))
+			t.Errorf("got next(%q, %q) = %q; want %q", tt.expr, t1.Format(layout),
+				got.Format(layout), t2.Format(layout))
 		}
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/cespare/cron
 
 go 1.14
+
+require github.com/google/go-cmp v0.5.9

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
+github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=


### PR DESCRIPTION
This has a few different changes:

* CR suggestions from #3
* Change `Schedule` from a pointer to value type
* Various code cleanups
* More documentation and test cases

After merging this I will cut a new version. The `Schedule` change is a breaking change so this technically should be v2, but I'm tempted to just do v1.1.0 since I'm pretty sure we're the only users of this package. (At least, there are no public users of it.)